### PR TITLE
一系列功能性和安全性改动

### DIFF
--- a/cmd/nps/nps.go
+++ b/cmd/nps/nps.go
@@ -1,14 +1,6 @@
 package main
 
 import (
-	"ehang.io/nps/lib/crypt"
-	"ehang.io/nps/lib/file"
-	"ehang.io/nps/lib/install"
-	"ehang.io/nps/lib/version"
-	"ehang.io/nps/server"
-	"ehang.io/nps/server/connection"
-	"ehang.io/nps/server/tool"
-	"ehang.io/nps/web/routers"
 	"flag"
 	"log"
 	"os"
@@ -18,7 +10,16 @@ import (
 	"strings"
 	"sync"
 
+	"ehang.io/nps/lib/file"
+	"ehang.io/nps/lib/install"
+	"ehang.io/nps/lib/version"
+	"ehang.io/nps/server"
+	"ehang.io/nps/server/connection"
+	"ehang.io/nps/server/tool"
+	"ehang.io/nps/web/routers"
+
 	"ehang.io/nps/lib/common"
+	"ehang.io/nps/lib/crypt"
 	"ehang.io/nps/lib/daemon"
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/logs"
@@ -200,7 +201,8 @@ func run() {
 	}
 	logs.Info("the version of server is %s ,allow client core version to be %s", version.VERSION, version.GetVersion())
 	connection.InitConnectionService()
-	crypt.InitTls(filepath.Join(common.GetRunPath(), "conf", "server.pem"), filepath.Join(common.GetRunPath(), "conf", "server.key"))
+	//crypt.InitTls(filepath.Join(common.GetRunPath(), "conf", "server.pem"), filepath.Join(common.GetRunPath(), "conf", "server.key"))
+	crypt.InitTls()
 	tool.InitAllowPort()
 	tool.StartSystemInfo()
 	go server.StartNewServer(bridgePort, task, beego.AppConfig.String("bridge_type"))

--- a/lib/crypt/tls.go
+++ b/lib/crypt/tls.go
@@ -1,22 +1,37 @@
 package crypt
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"log"
+	"math/big"
 	"net"
 	"os"
+	"time"
 
 	"github.com/astaxie/beego/logs"
 )
 
-var pemPath, keyPath string
+var (
+	cert tls.Certificate
+)
 
-func InitTls(pem, key string) {
-	pemPath = pem
-	keyPath = key
+func InitTls() {
+	c, k, err := generateKeyPair("NPS Corp,.Inc")
+	if err == nil {
+		cert, err = tls.X509KeyPair(c, k)
+	}
+	if err != nil {
+		log.Fatalln("Error initializing crypto certs", err)
+	}
 }
 
 func NewTlsServerConn(conn net.Conn) net.Conn {
-	cert, err := tls.LoadX509KeyPair(pemPath, keyPath)
+	var err error
 	if err != nil {
 		logs.Error(err)
 		os.Exit(0)
@@ -31,4 +46,42 @@ func NewTlsClientConn(conn net.Conn) net.Conn {
 		InsecureSkipVerify: true,
 	}
 	return tls.Client(conn, conf)
+}
+
+func generateKeyPair(CommonName string) (rawCert, rawKey []byte, err error) {
+	// Create private key and self-signed certificate
+	// Adapted from https://golang.org/src/crypto/tls/generate_cert.go
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return
+	}
+	validFor := time.Hour * 24 * 365 * 10 // ten years
+	notBefore := time.Now()
+	notAfter := notBefore.Add(validFor)
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"My Company Name LTD."},
+			CommonName:   CommonName,
+			Country:      []string{"US"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return
+	}
+
+	rawCert = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	rawKey = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+
+	return
 }

--- a/server/proxy/http.go
+++ b/server/proxy/http.go
@@ -155,13 +155,8 @@ func NewHttpReverseProxy(s *httpServer) *HttpReverseProxy {
 	local, _ := net.ResolveTCPAddr("tcp", "127.0.0.1")
 	proxy := NewReverseProxy(&httputil.ReverseProxy{
 		Director: func(r *http.Request) {
-			r.URL.Host = r.Host
-			if host, err := file.GetDb().GetInfoByHost(r.Host, r); err != nil {
-				logs.Notice("the url %s %s %s can't be parsed!", r.URL.Scheme, r.Host, r.RequestURI)
-				return
-			} else {
-				common.ChangeHostAndHeader(r, host.HostChange, host.HeaderChange, "", false)
-			}
+			host := r.Context().Value("host").(*file.Host)
+			common.ChangeHostAndHeader(r, host.HostChange, host.HeaderChange, "", false)
 		},
 		Transport: &http.Transport{
 			ResponseHeaderTimeout: rp.responseHeaderTimeout,

--- a/server/proxy/http.go
+++ b/server/proxy/http.go
@@ -132,6 +132,7 @@ func (rp *HttpReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 	if host.Client.Cnf.U != "" && host.Client.Cnf.P != "" && !common.CheckAuth(req, host.Client.Cnf.U, host.Client.Cnf.P) {
+		rw.Header().Set("WWW-Authenticate", "Basic realm=\"Private Area\"")
 		rw.WriteHeader(http.StatusUnauthorized)
 		rw.Write([]byte("Unauthorized"))
 		return
@@ -141,6 +142,7 @@ func (rp *HttpReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 		rw.Write([]byte("502 Bad Gateway"))
 		return
 	}
+	req.URL.Host = req.Host
 	req = req.WithContext(context.WithValue(req.Context(), "host", host))
 	req = req.WithContext(context.WithValue(req.Context(), "target", targetAddr))
 	req = req.WithContext(context.WithValue(req.Context(), "req", req))

--- a/server/proxy/reverseproxy.go
+++ b/server/proxy/reverseproxy.go
@@ -1,0 +1,136 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// HTTP reverse proxy handler
+
+package proxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+type HTTPError struct {
+	error
+	HTTPCode int
+}
+
+func NewHTTPError(code int, errmsg string) error {
+	return &HTTPError{
+		error:    errors.New(errmsg),
+		HTTPCode: code,
+	}
+}
+
+type ReverseProxy struct {
+	*httputil.ReverseProxy
+	WebSocketDialContext func(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+func IsWebsocketRequest(req *http.Request) bool {
+	containsHeader := func(name, value string) bool {
+		items := strings.Split(req.Header.Get(name), ",")
+		for _, item := range items {
+			if value == strings.ToLower(strings.TrimSpace(item)) {
+				return true
+			}
+		}
+		return false
+	}
+	return containsHeader("Connection", "upgrade") && containsHeader("Upgrade", "websocket")
+}
+
+func NewSingleHostReverseProxy(target *url.URL) *ReverseProxy {
+	rp := &ReverseProxy{
+		ReverseProxy:         httputil.NewSingleHostReverseProxy(target),
+		WebSocketDialContext: nil,
+	}
+	rp.ErrorHandler = rp.errHandler
+	return rp
+}
+
+func NewReverseProxy(orp *httputil.ReverseProxy) *ReverseProxy {
+	rp := &ReverseProxy{
+		ReverseProxy:         orp,
+		WebSocketDialContext: nil,
+	}
+	rp.ErrorHandler = rp.errHandler
+	return rp
+}
+
+func (p *ReverseProxy) errHandler(rw http.ResponseWriter, r *http.Request, e error) {
+	if e == io.EOF {
+		rw.WriteHeader(521)
+		//rw.Write(getWaitingPageContent())
+	} else {
+		if httperr, ok := e.(*HTTPError); ok {
+			rw.WriteHeader(httperr.HTTPCode)
+		} else {
+			rw.WriteHeader(http.StatusNotFound)
+		}
+		rw.Write([]byte("error: " + e.Error()))
+	}
+}
+
+func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if IsWebsocketRequest(req) {
+		p.serveWebSocket(rw, req)
+	} else {
+		p.ReverseProxy.ServeHTTP(rw, req)
+	}
+}
+
+func (p *ReverseProxy) serveWebSocket(rw http.ResponseWriter, req *http.Request) {
+	if p.WebSocketDialContext == nil {
+		rw.WriteHeader(500)
+		return
+	}
+	targetConn, err := p.WebSocketDialContext(req.Context(), "tcp", "")
+	if err != nil {
+		rw.WriteHeader(501)
+		return
+	}
+	defer targetConn.Close()
+
+	p.Director(req)
+
+	hijacker, ok := rw.(http.Hijacker)
+	if !ok {
+		rw.WriteHeader(500)
+		return
+	}
+	conn, _, errHijack := hijacker.Hijack()
+	if errHijack != nil {
+		rw.WriteHeader(500)
+		return
+	}
+	defer conn.Close()
+
+	req.Write(targetConn)
+	Join(conn, targetConn)
+}
+
+func Join(c1 io.ReadWriteCloser, c2 io.ReadWriteCloser) (inCount int64, outCount int64) {
+	var wait sync.WaitGroup
+	pipe := func(to io.ReadWriteCloser, from io.ReadWriteCloser, count *int64) {
+		defer to.Close()
+		defer from.Close()
+		defer wait.Done()
+
+		*count, _ = io.Copy(to, from)
+	}
+
+	wait.Add(2)
+	go pipe(c1, c2, &inCount)
+	go pipe(c2, c1, &outCount)
+	wait.Wait()
+	return
+}

--- a/server/test/test.go
+++ b/server/test/test.go
@@ -52,10 +52,10 @@ func TestServerConfig() {
 			if port, err := strconv.Atoi(p); err != nil {
 				log.Fatalln("get https port error", err)
 			} else {
-				if !common.FileExists(filepath.Join(common.GetRunPath(), beego.AppConfig.String("pemPath"))) {
+				if beego.AppConfig.String("pemPath") != "" && !common.FileExists(filepath.Join(common.GetRunPath(), beego.AppConfig.String("pemPath"))) {
 					log.Fatalf("ssl certFile %s is not exist", beego.AppConfig.String("pemPath"))
 				}
-				if !common.FileExists(filepath.Join(common.GetRunPath(), beego.AppConfig.String("ketPath"))) {
+				if beego.AppConfig.String("keyPath") != "" && !common.FileExists(filepath.Join(common.GetRunPath(), beego.AppConfig.String("keyPath"))) {
 					log.Fatalf("ssl keyFile %s is not exist", beego.AppConfig.String("pemPath"))
 				}
 				isInArr(&postTcpArr, port, "http port", "tcp")


### PR DESCRIPTION
去掉nps原有的http代理，改用httputil.reverseproxy，可以支持ws
去掉基于server.key和server.pem的tls连接，改为在启动时动态生成证书（代码部分来自gost）

新的反向代理支持了流量统计和用户认证等，但不支持连接数统计。不支持http_cache。

所有改动不需要改动原有客户端，和现有客户端完全兼容