### PR TITLE
enable comment of conf titles

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -302,7 +302,7 @@ func delLocalService(s string) *LocalServer {
 
 func getAllTitle(content string) (arr []string, err error) {
 	var re *regexp.Regexp
-	re, err = regexp.Compile(`\[.+?\]`)
+	re, err = regexp.Compile(`(?m)^\[[^\[\]\r\n]+\]`)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
简单处理一下可以更好地支持注释

```
[common]
server_addr=1.1.1.1:8024
conn_type=tcp
vkey=123

#[tcp]
#mode=tcp
#target_addr=127.0.0.1:8080

#[p2p_ssh]
#local_port=2002
#password=ssh3
#target_addr=123.206.77.88:22
```

否则不支持注释 title，会被匹配到 title 最后在 npc 中出错。

这只是个简单的 fix，但感觉 nps 对于 config 的解析代码这块可能需要重新考虑一下，正则太暴力了 （例如 [go-ini/ini](https://github.com/go-ini/ini)）。

很好用的工具，感谢。