### PR TITLE
fix: fix localhost proxy

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -24,9 +24,9 @@ import (
 )
 
 type Client struct {
-	tunnel    *nps_mux.Mux
-	signal    *conn.Conn
-	file      *nps_mux.Mux
+	tunnel    *nps_mux.Mux // WORK_CHAN connection
+	signal    *conn.Conn   // WORK_MAIN connection
+	file      *nps_mux.Mux //  WORK_FILE connection
 	Version   string
 	retryTime int // it will be add 1 when ping not ok until to 3 will close the client
 }

--- a/lib/file/obj.go
+++ b/lib/file/obj.go
@@ -25,8 +25,8 @@ func (s *Flow) Add(in, out int64) {
 }
 
 type Config struct {
-	U        string
-	P        string
+	U        string  // username
+	P        string  // password
 	Compress bool
 	Crypt    bool
 }

--- a/server/proxy/socks5.go
+++ b/server/proxy/socks5.go
@@ -96,6 +96,9 @@ func (s *Sock5ModeServer) sendReply(c net.Conn, rep uint8) {
 	localAddr := c.LocalAddr().String()
 	localHost, localPort, _ := net.SplitHostPort(localAddr)
 	ipBytes := net.ParseIP(localHost).To4()
+	if ipBytes == nil {
+		ipBytes = net.ParseIP("127.0.0.1").To4()
+	}
 	nPort, _ := strconv.Atoi(localPort)
 	reply = append(reply, ipBytes...)
 	portBytes := make([]byte, 2)


### PR DESCRIPTION
通过nps在本地启动一个socks5代理localhost:8003，然后使用执行以下shell命令：

curl -x socks5h://localhost:8003 https://www.baidu.com

会发现curl命令卡住了。原因是ipBytes为nil。