### PR TITLE
#789 修复Http代理,Socks5代理的auth无法正常使用

### DIFF
--- a/lib/common/const.go
+++ b/lib/common/const.go
@@ -27,11 +27,15 @@ const (
 	CONN_TCP          = "tcp"
 	CONN_UDP          = "udp"
 	CONN_TEST         = "TST"
-	UnauthorizedBytes = `HTTP/1.1 401 Unauthorized
-Content-Type: text/plain; charset=utf-8
-WWW-Authenticate: Basic realm="easyProxy"
+	UnauthorizedBytes = `HTTP/1.1 407 Proxy Authentication Required
+Server: Proxy
+Proxy-Authenticate: Basic realm="easyProxy Authentication"
+Connection: Close
+Proxy-Connection: Close
+Content-Length: 0
 
-401 Unauthorized`
+`
+
 	ConnectionFailBytes = `HTTP/1.1 404 Not Found
 
 `

--- a/lib/common/util.go
+++ b/lib/common/util.go
@@ -50,6 +50,28 @@ func DomainCheck(domain string) bool {
 	return match
 }
 
+// 判断是否有有效的账号
+func hasValidAccount(accountMap map[string]string) bool {
+	if accountMap == nil {
+		return false
+	}
+
+	for u, p := range accountMap {
+		if u != "" && p != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// 判断是否需要验证
+// user global user
+// passwd global passwd
+// accountMap enable multi user auth
+func HasValid(user, passwd string, accountMap map[string]string) bool {
+	return hasValidAccount(accountMap) || (user != "" && passwd != "")
+}
+
 // CheckAuthWithAccountMap
 // u current login user
 // p current login passwd
@@ -57,6 +79,11 @@ func DomainCheck(domain string) bool {
 // passwd global passwd
 // accountMap enable multi user auth
 func checkAuthWithAccountMap(u, p, user, passwd string, accountMap map[string]string) bool {
+	// 是否需要验证
+	if !HasValid(user, passwd, accountMap) {
+		return true
+	}
+
 	// invalid user or passwd
 	if u == "" || p == "" {
 		return false
@@ -91,6 +118,11 @@ func CheckAuthWithAccountMap(u, p, user, passwd string, accountMap map[string]st
 
 //Check if the Request request is validated
 func CheckAuth(r *http.Request, user, passwd string, accountMap map[string]string) bool {
+	// 是否需要验证
+	if !HasValid(user, passwd, accountMap) {
+		return true
+	}
+
 	s := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
 	if len(s) != 2 {
 		s = strings.SplitN(r.Header.Get("Proxy-Authorization"), " ", 2)

--- a/server/proxy/base.go
+++ b/server/proxy/base.go
@@ -65,7 +65,7 @@ func (s *BaseServer) writeConnFail(c net.Conn) {
 
 //auth check
 func (s *BaseServer) auth(r *http.Request, c *conn.Conn, u, p string, AccountMap map[string]string) error {
-	if u != "" && p != "" && !common.CheckAuth(r, u, p, AccountMap) {
+	if !common.CheckAuth(r, u, p, AccountMap) {
 		var resp = common.UnauthorizedBytes
 		resp = strings.ReplaceAll(resp, "\n", "\r\n")
 		c.Write([]byte(resp))

--- a/server/proxy/base.go
+++ b/server/proxy/base.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 
 	"ehang.io/nps/bridge"
@@ -63,11 +64,13 @@ func (s *BaseServer) writeConnFail(c net.Conn) {
 }
 
 //auth check
-func (s *BaseServer) auth(r *http.Request, c *conn.Conn, u, p string) error {
-	if u != "" && p != "" && !common.CheckAuth(r, u, p) {
-		c.Write([]byte(common.UnauthorizedBytes))
+func (s *BaseServer) auth(r *http.Request, c *conn.Conn, u, p string, AccountMap map[string]string) error {
+	if u != "" && p != "" && !common.CheckAuth(r, u, p, AccountMap) {
+		var resp = common.UnauthorizedBytes
+		resp = strings.ReplaceAll(resp, "\n", "\r\n")
+		c.Write([]byte(resp))
 		c.Close()
-		return errors.New("401 Unauthorized")
+		return errors.New("407 Unauthorized")
 	}
 	return nil
 }

--- a/server/proxy/http.go
+++ b/server/proxy/http.go
@@ -150,7 +150,7 @@ reset:
 	if !isReset {
 		defer host.Client.AddConn()
 	}
-	if err = s.auth(r, c, host.Client.Cnf.U, host.Client.Cnf.P); err != nil {
+	if err = s.auth(r, c, host.Client.Cnf.U, host.Client.Cnf.P, s.task.MultiAccount.AccountMap); err != nil {
 		logs.Warn("auth error", err, r.RemoteAddr)
 		return
 	}

--- a/server/proxy/https.go
+++ b/server/proxy/https.go
@@ -117,7 +117,7 @@ func (https *HttpsServer) handleHttps(c net.Conn) {
 		return
 	}
 	defer host.Client.AddConn()
-	if err = https.auth(r, conn.NewConn(c), host.Client.Cnf.U, host.Client.Cnf.P); err != nil {
+	if err = https.auth(r, conn.NewConn(c), host.Client.Cnf.U, host.Client.Cnf.P, https.task.MultiAccount.AccountMap); err != nil {
 		logs.Warn("auth error", err, r.RemoteAddr)
 		return
 	}

--- a/server/proxy/socks5.go
+++ b/server/proxy/socks5.go
@@ -340,21 +340,7 @@ func (s *Sock5ModeServer) Auth(c net.Conn) error {
 		return err
 	}
 
-	var U, P string
-	if s.task.MultiAccount != nil {
-		// enable multi user auth
-		U = string(user)
-		var ok bool
-		P, ok = s.task.MultiAccount.AccountMap[U]
-		if !ok {
-			return errors.New("验证不通过")
-		}
-	} else {
-		U = s.task.Client.Cnf.U
-		P = s.task.Client.Cnf.P
-	}
-
-	if string(user) == U && string(pass) == P {
+	if common.CheckAuthWithAccountMap(string(user), string(pass), s.task.Client.Cnf.U, s.task.Client.Cnf.P, s.task.MultiAccount.AccountMap) {
 		if _, err := c.Write([]byte{userAuthVersion, authSuccess}); err != nil {
 			return err
 		}

--- a/server/proxy/socks5.go
+++ b/server/proxy/socks5.go
@@ -302,7 +302,13 @@ func (s *Sock5ModeServer) handleConn(c net.Conn) {
 		c.Close()
 		return
 	}
-	if (s.task.Client.Cnf.U != "" && s.task.Client.Cnf.P != "") || (s.task.MultiAccount != nil && len(s.task.MultiAccount.AccountMap) > 0) {
+
+	var accountMap map[string]string = nil
+	if s.task.MultiAccount != nil {
+		accountMap = s.task.MultiAccount.AccountMap
+	}
+
+	if common.HasValid(s.task.Client.Cnf.U, s.task.Client.Cnf.P, accountMap) {
 		buf[1] = UserPassAuth
 		c.Write(buf)
 		if err := s.Auth(c); err != nil {


### PR DESCRIPTION
修复Http代理,Socks5代理的auth无法正常使用,现在可以同时使用全局用户和mutli user认证了,认证失败,客户端会提示输入用户名和密码