### PR TITLE
fix: nat指定目标stun服务后，保证服务地址读取成功

### DIFF
--- a/cmd/npc/npc.go
+++ b/cmd/npc/npc.go
@@ -115,6 +115,7 @@ func main() {
 			return
 		case "nat":
 			c := stun.NewClient()
+			flag.CommandLine.Parse(os.Args[2:])
 			c.SetServerAddr(*stunAddr)
 			nat, host, err := c.Discover()
 			if err != nil || host == nil {


### PR DESCRIPTION
现在的代码在 npc 指定stun地址测试时，会存在读不到参数的问题，修复该问题